### PR TITLE
Remove hardcoded payment method type

### DIFF
--- a/public/lib/commands/stripe_checkout/create/build.liquid
+++ b/public/lib/commands/stripe_checkout/create/build.liquid
@@ -1,6 +1,5 @@
 {% liquid
-  assign payment_method_types = 'card' | split: ','
-  assign payload = null | hash_merge: payment_method_types: payment_method_types, client_reference_id: transaction.id, mode: "payment"
+  assign payload = null | hash_merge: client_reference_id: transaction.id, mode: "payment"
   assign payload = object | hash_merge: payload
 
   assign data = null | hash_merge: payload: payload, request_type: 'POST', to: 'https://api.stripe.com/v1/checkout/sessions'


### PR DESCRIPTION
# Description

Remove hardcoded payment method type. We can pass it in the `object` and if we don't set it, stripe will use the account's settings.

## Issue ticket number and link

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
